### PR TITLE
List available commands on failure

### DIFF
--- a/upscmd.py
+++ b/upscmd.py
@@ -11,22 +11,28 @@ else:
     print("the ups command to issue is missing.")
     print("example: upscmd.py beeper.enable")
     exit(1)
-    
 
 tn = telnetlib.Telnet("127.0.0.1", 3493)
 
 tn.write("USERNAME {0}\n".format(user))
 response = tn.read_until("OK", timeout=2)
-print "USERNAME cmd status: {0}".format(response.strip())
+print("USERNAME: {0}".format(response.strip()))
 
 tn.write("PASSWORD {0}\n".format(pwd))
 response = tn.read_until("OK", timeout=2)
-print "PASSWORD cmd status: {0}".format(response.strip())
+print("PASSWORD: {0}".format(response.strip()))
 
 tn.write("INSTCMD ups {0}\n".format(cmd))
 response = tn.read_until("OK", timeout=2)
-print "INSTCMD cmd status: {0}".format(response.strip())
+print("INSTCMD ups {0}: {1}".format(cmd, response.strip()))
+
+if response.strip() != "OK":
+  tn.write("LIST CMD ups\n")
+  response = tn.read_until("END LIST CMD ups", timeout=2)
+  print("\n>> AVAILABLE CMDS:")
+  cmds = response.splitlines()[1:-1]
+  for cmd in cmds:
+    print(cmd.replace("CMD ups ", "- "))
 
 tn.write("LOGOUT\n")
-print tn.read_all()
-
+print tn.read_all().rstrip("\n")


### PR DESCRIPTION
My particular UPS doesn't have `beeper.enable|disable`, but instead only has a single `beeper.toggle`

Example output:
```
$ ./ups_cmd.py oops
USERNAME: OK
PASSWORD: OK
INSTCMD ups oops: ERR CMD-NOT-SUPPORTED

>> AVAILABLE CMDS:
- beeper.toggle
- load.off
- load.on
- shutdown.return
- shutdown.stayoff
- shutdown.stop
- test.battery.start
- test.battery.start.deep
- test.battery.start.quick
- test.battery.stop

OK Goodbye
```

NOTE: `LIST CMD` returns something like:
```
BEGIN LIST CMD ups
CMD ups beeper.toggle
CMD ups load.off
CMD ups load.on
CMD ups shutdown.return
CMD ups shutdown.stayoff
CMD ups shutdown.stop
CMD ups test.battery.start
CMD ups test.battery.start.deep
CMD ups test.battery.start.quick
CMD ups test.battery.stop
END LIST CMD ups
```
